### PR TITLE
Move to (cljs.core/random-uuid) because of compatibility reasons

### DIFF
--- a/upload-manager/src/simplemono/segment_upload/upload_segment.cljs
+++ b/upload-manager/src/simplemono/segment_upload/upload_segment.cljs
@@ -69,7 +69,7 @@
   (do
     (def state
       (atom
-        {:segment-uuid (js/crypto.randomUUID)
+        {:segment-uuid (random-uuid)
          :segment-blob (js/Blob. ["hello"]
                                  #js {:type "text/plain"}
                                  )

--- a/upload-manager/src/simplemono/segment_upload/upload_segments.cljs
+++ b/upload-manager/src/simplemono/segment_upload/upload_segments.cljs
@@ -31,7 +31,7 @@
                  (let [[start end] slice-range
                        segment-size (- end start)]
                    {:index index
-                    :segment-uuid (js/crypto.randomUUID)
+                    :segment-uuid (random-uuid)
                     :progress 0
                     :size segment-size
                     :slice-range slice-range


### PR DESCRIPTION
Moved to `(cljs.core/random-uuid)` because `(js/crypto.randomUUID)` is not supported by older browsers