### PR TITLE
Increased upload speed when using the default parameter

### DIFF
--- a/upload-manager/src/simplemono/segment_upload/upload_manager.cljs
+++ b/upload-manager/src/simplemono/segment_upload/upload_manager.cljs
@@ -13,7 +13,10 @@
 
 (defn add-upload
   [w upload]
-  (let [upload* (-> upload
+  (let [upload* (-> w
+                    (select-keys [:slice-size
+                                  :max-parallel-uploads])
+                    (merge upload)
                     ensure-id
                     (assoc :added (js/Date.)))]
     (assoc-in w

--- a/upload-manager/src/simplemono/segment_upload/upload_manager.cljs
+++ b/upload-manager/src/simplemono/segment_upload/upload_manager.cljs
@@ -111,7 +111,7 @@
 
 (defn create
   [w]
-  (merge {:max-parallel-uploads 2
+  (merge {:max-parallel-uploads 8
           :drive! drive!}
          w))
 

--- a/upload-manager/src/simplemono/segment_upload/upload_segments.cljs
+++ b/upload-manager/src/simplemono/segment_upload/upload_segments.cljs
@@ -210,7 +210,7 @@
 (def defaults
   {:segment-upload-url "/segment-upload/upload/"
    :slice-size (* 1024 1024)
-   :max-parallel-uploads 2
+   :max-parallel-uploads 8
    :upload-segment! upload-segment/upload-segment!
    :drive! drive!})
 


### PR DESCRIPTION
- Increased the default value for `:max-parallel-uploads` to a size that is reasonable for a production app.

- Fix: `:slice-size` and `:max-parallel-uploads` should be take over from
the state, when a new upload is added.