### PR TITLE
BREAKING CHANGE to fix double upload issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ The focus is to provide a solution to overcome a potentially slow and unstable
 connection of an end-user that tries to upload a file. As soon as the file resides on fast and reliable storage, like S3 or Google Cloud Storage, the
 server can download the file from there with a single GET request.
 
-The mini-framework allows uploading segments of a file to such storage (only
+The mini-framework allows uploading segments of a file to such a storage (only
 Google Cloud Storage at the moment) or the local file system of the server.
-However, 'file' is misleading since the segments are just binary
-data (blob) without a filename. Instead, everything is named with a UUID. After
-all segments have been uploaded, they can be composed in a second step into a blob
-named with a UUID. The compose step returns an URL that the client
-can pass to the server's API. It is up to the server what it does with this
-binary data. Thereby neither the purpose of the binary data nor any details of
-the server API are intertwined with this mini-framework.
+However, 'file' is misleading since the segments are just binary data (blob)
+without a filename. Instead, everything is named with an UUID. After all
+segments have been uploaded, they can be composed in a second step into a blob
+named with an UUID. The compose step returns an URL that the client can pass to
+the server's API. It is up to the server what it does with this binary data.
+Thereby neither the purpose of the binary data nor any details of the server API
+are intertwined with this mini-framework.
 
 Another complexity that is avoided is authentication. Uploading and composing
 segments are public endpoints. However, you can add rate limiting and
@@ -45,28 +45,28 @@ URL the (random) UUID of a segment can act as a secret. Last but not least,
 Google Cloud Storage's lifecycle feature can automatically delete all
 files older than 24 hours, for example.
 
-The upload of a segment is initialized with a PUT request to:
+The upload of a segment is initialized with a GET request to:
 
 ```
-HTTP PUT /segment-upload/upload/{UUID}
+HTTP GET /segment-upload/upload/{UUID}
 ```
 
 Please generate a random UUID and replace the `{UUID}`
 ([JS](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID),
 [Java](https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html#randomUUID--)).
 
-The response will be a [HTTP
-307](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307), where the
-location header contains a signed URL. Some HTTP clients, like JavaScript's
-`fetch` or `XHR` automatically follow the redirect and repeat the PUT request on
-the URL returned in the location header. Others, like curl do not do this
-automatically:
+The response contains JSON:
 
-``` sh
-curl -L -v -X PUT -d "hello" "http://example.com/segment-upload/upload/`uuid`"
+``` json
+{"url": "https://example.com/some-signed-upload-url"}
 ```
 
-Here the `-L` flag was added to activate this behavior.
+The next step is to send the binary content of the segment to this URL via a PUT
+request:
+
+```
+HTTP PUT https://example.com/some-signed-upload-url
+```
 
 After all segments have been uploaded successfully, the compose endpoint should
 be used:
@@ -88,11 +88,12 @@ The response will contain a JSON body as well:
 {"url" : "{a signed URL}"}
 ```
 
-The returned signed URL will be valid for 10 minutes, enough time to use it with another server API. An API consumer would also have the
-option to use his server, S3, Google Cloud Storage, etc., to host the file
-contents. Thereby the API is not entangled with the upload mechanism. One neat
-detail is that Google Cloud Storage offers an API call to compose objects in the
-same bucket. Thereby these objects do not have to be downloaded to compose them.
+The returned signed URL will be valid for 10 minutes, enough time to use it with
+another server API. An API consumer would also have the option to use his
+server, S3, Google Cloud Storage, etc., to host the file contents. Thereby the
+API is not entangled with the upload mechanism. One neat detail is that Google
+Cloud Storage offers an API call to compose objects in the same bucket. Thereby
+these objects do not have to be downloaded to compose them.
 
 ## ClojureScript client
 

--- a/core/src/simplemono/segment_upload/core.clj
+++ b/core/src/simplemono/segment_upload/core.clj
@@ -1,10 +1,9 @@
 (ns simplemono.segment-upload.core
-  (:require [ring.util.response :as response]
-            [simplemono.segment-upload.util :as util]
+  (:require [simplemono.segment-upload.util :as util]
             [simplemono.world.core :as w]
             ))
 
-(defn put-upload-ring-handler
+(defn get-upload-ring-handler
   [{:keys [ring/route-params segment-upload/get-upload-url] :as w}]
   (when-let [uuid (util/to-uuid (:uuid route-params))]
     (let [upload-url (get-upload-url (assoc w
@@ -12,8 +11,7 @@
                                             uuid))]
       (assoc w
              :ring/response
-             (response/redirect upload-url
-                                307))
+             (util/json-response {:url upload-url}))
       )))
 
 (defn check-segment-count
@@ -72,77 +70,79 @@
   [w]
   (-> w
       (assoc-in [:ring/routes
-                 [:put "/segment-upload/upload/:uuid"]]
-                #'put-upload-ring-handler)
+                 [:get "/segment-upload/upload/:uuid"]]
+                #'get-upload-ring-handler)
       (assoc-in [:ring/routes
                  [:post "/segment-upload/compose"]]
                 #'compose-segments-ring-handler)))
 
 (comment
-  (require '[clj-http.client :as http]
-           '[clojure.string :as str])
+  (require '[clj-http.client :as http])
 
-  (def example-uuid
-    (java.util.UUID/randomUUID))
+  ;; Example of a basic upload client implementation:
 
-  (def example-request
-    {:request-method :put
-     :url (str "http://localhost:8080/segment-upload/upload/"
-               example-uuid)
-     :body "hello"})
+  (defn get-upload-url
+    "Gets a signed upload URL from the server."
+    [{:keys [base-url uuid]}]
+    (-> {:request-method :get
+         :url (str base-url
+                   "/segment-upload/upload/"
+                   uuid)
+         :as :json}
+        (http/request)
+        (get-in [:body :url])))
 
-  (let [location (get-in (http/request example-request)
-                         [:headers
-                          "Location"])]
-    (http/request
-      (assoc example-request
-             :url
-             (if (str/starts-with? location
-                                   "/")
-               (str "http://localhost:8080"
-                    location)
-               location))))
+  (get-upload-url
+    {:base-url "http://localhost:8080"
+     :uuid (random-uuid)})
 
   (defn upload-segment!
-    [{:keys [base-url uuid content]}]
-    (let [request {:request-method :put
-                   :url (str base-url
-                             "/segment-upload/upload/"
-                             uuid)
-                   :headers {"Content-Type" "text/plain"}
-                   :body content}
-          location (get-in (http/request request)
-                           [:headers
-                            "Location"])]
+    "Uploads the `:content` as segment."
+    [{:keys [uuid content] :as params}]
+    (let [upload-url (get-upload-url params)]
       (http/request
-        (assoc request
-               :url
-               (if (str/starts-with? location
-                                     "/")
-                 (str base-url
-                      location)
-                 location)))
+        {:request-method :put
+         :url upload-url
+         :headers {"Content-Type" "text/plain"}
+         :body content})
       {:uuid uuid}))
 
+  (def content
+    ;; Example content to upload:
+    "hello upload")
+
   (def example-uuids
-    (repeatedly 10
+    ;; UUIDs for the segments. Just for demonstration purposes we upload each
+    ;; letter as separate segment:
+    (repeatedly (count content)
                 (fn []
                   (java.util.UUID/randomUUID))))
 
-  (doseq [[n uuid] (map-indexed vector
-                                example-uuids)]
+  ;; Uploads all segments:
+  (doseq [[letter uuid] (map vector
+                             content
+                             example-uuids)]
     (upload-segment! {:base-url "http://localhost:8080"
                       :uuid uuid
-                      :content (str (inc n)
-                                    "\n")}))
+                      :content (str letter)}))
 
-  (http/request
-    {:request-method :post
-     :url "http://localhost:8080/segment-upload/compose"
-     :content-type :json
-     :form-params {:uuids example-uuids}
-     })
+  (def composed-url
+    ;; Composes all segments into a single file on the server that can be
+    ;; downloaded via the `composed-url`:
+    (-> {:request-method :post
+         :url "http://localhost:8080/segment-upload/compose"
+         :content-type :json
+         :form-params {:uuids example-uuids}
+         :as :json
+         }
+        (http/request)
+        (get-in [:body :url])))
 
-  ;; JS example:
-  ;; fetch('/segment-upload/upload/' + crypto.randomUUID(), {method: 'PUT', body: 'hello from js'})
+  ;; The composed file should have the uploaded `content`:
+  (= content
+     (-> composed-url
+         (http/get)
+         (:body))
+     )
+
   )

--- a/core/src/simplemono/segment_upload/core.clj
+++ b/core/src/simplemono/segment_upload/core.clj
@@ -11,7 +11,7 @@
                                             uuid))]
       (assoc w
              :ring/response
-             (util/json-response {:url upload-url}))
+             (util/json-response {:url (str upload-url)}))
       )))
 
 (defn check-segment-count


### PR DESCRIPTION
Regrettably, I had to do a breaking change, since the HTTP 307 does not work like I thought. HTTP clients (like Chrome) send the full body of the PUT request, despite of receiving a HTTP 307 with a location header for a redirect. For that reason the segment's content is effectively send twice. To prevent this double upload, the upload-manager now sends an HTTP GET request to receive an upload-url, before its send a PUT request to this URL with the segment's content.